### PR TITLE
tests: don't use single-argument `map`

### DIFF
--- a/EasyJobsBase/test/async.jl
+++ b/EasyJobsBase/test/async.jl
@@ -109,7 +109,8 @@ end
     f₂() = read("file", String)
     h = Job(Thunk(sleep, 3); username="me", name="h")
     i = Job(Thunk(f₁, 1001); username="me", name="i")
-    j = ConditionalJob(Thunk(map, f₂); username="he", name="j")
+    caller = f -> f()
+    j = ConditionalJob(Thunk(caller, f₂); username="he", name="j")
     [h, i] .→ j
     @test !shouldrun(j)
     @test_throws AssertionError run!(j)

--- a/test/async.jl
+++ b/test/async.jl
@@ -109,7 +109,8 @@ end
     f₂() = read("file", String)
     h = Job(Thunk(sleep, 3); username="me", name="h")
     i = Job(Thunk(f₁, 1001); username="me", name="i")
-    j = ConditionalJob(Thunk(map, f₂); username="he", name="j")
+    caller = f -> f()
+    j = ConditionalJob(Thunk(caller, f₂); username="he", name="j")
     [h, i] .→ j
     @test !shouldrun(j)
     @test_throws AssertionError run!(j)


### PR DESCRIPTION
Single-argument `map` is being removed from Julia after an analysis of registered packages found that the change doesn't break the functionality of any package. See JuliaLang/julia#35293 and JuliaLang/julia#52631

That said, the Julia change breaks your test suite, so here's a PR that fixes that.